### PR TITLE
Fixed Issue with bundle.namespace in uadetector-resources osgi bundle

### DIFF
--- a/modules/uadetector-resources/pom.xml
+++ b/modules/uadetector-resources/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<bundle.symbolicName>net.sf.uadetector.resources</bundle.symbolicName>
-		<bundle.namespace>net.sf.uadetector.resources</bundle.namespace>
+		<bundle.namespace>net.sf.uadetector.service</bundle.namespace>
 	</properties>
 
 	<artifactId>uadetector-resources</artifactId>


### PR DESCRIPTION
Please merge this pull request to ensure that the package net.sf.uadetector.service package is properly exported via maven bundle plugin.
